### PR TITLE
feat(common): add TCCLI profile provider to default chain

### DIFF
--- a/tencentcloud/common/provider_chain.go
+++ b/tencentcloud/common/provider_chain.go
@@ -18,10 +18,20 @@ func NewProviderChain(providers []Provider) Provider {
 // DefaultProviderChain returns a default provider chain and try to get credentials in the following order:
 //  1. Environment variable
 //  2. Profile
-//  3. CvmRole
+//  3. TCCLI profile
+//  4. TKE OIDC role ARN
+//  5. CvmRole
+//
 // If you want to customize the search order, please use the function NewProviderChain
 func DefaultProviderChain() Provider {
-	return NewProviderChain([]Provider{DefaultEnvProvider(), DefaultProfileProvider(), DefaultCvmRoleProvider()})
+	providers := []Provider{DefaultEnvProvider(), DefaultProfileProvider(), DefaultTccliProfileProvider()}
+	tkeOIDCRoleArnProvider, err := DefaultTkeOIDCRoleArnProvider()
+	if err == nil {
+		providers = append(providers, tkeOIDCRoleArnProvider)
+	}
+	providers = append(providers, DefaultCvmRoleProvider())
+
+	return NewProviderChain(providers)
 }
 
 func (c *ProviderChain) GetCredential() (CredentialIface, error) {

--- a/tencentcloud/common/tccli_profile_provider.go
+++ b/tencentcloud/common/tccli_profile_provider.go
@@ -1,0 +1,74 @@
+package common
+
+import (
+	"os"
+	"path/filepath"
+
+	tcerr "github.com/tencentcloud/tencentcloud-sdk-go-intl-en/tencentcloud/common/errors"
+	"github.com/tencentcloud/tencentcloud-sdk-go-intl-en/tencentcloud/common/json"
+)
+
+const (
+	EnvTencentCloudProfile = "TENCENTCLOUD_PROFILE"
+)
+
+type TccliProfileProvider struct {
+	profile string
+}
+
+func DefaultTccliProfileProvider() *TccliProfileProvider {
+	profile, ok := os.LookupEnv(EnvTencentCloudProfile)
+	if !ok {
+		profile = "default"
+	}
+
+	return &TccliProfileProvider{profile: profile}
+}
+
+func (p *TccliProfileProvider) checkCredentialFile() (string, error) {
+	path := filepath.Join(getHomePath(), ".tccli", p.profile+".credential")
+	if path == "" {
+		return path, nil
+	}
+	_, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	return path, nil
+}
+
+func (p *TccliProfileProvider) GetCredential() (CredentialIface, error) {
+	path, err := p.checkCredentialFile()
+	if err != nil {
+		return nil, tcerr.NewTencentCloudSDKError(creErr, "Failed to find profile file, "+err.Error(), "")
+	}
+	if path == "" {
+		return nil, fileDoseNotExist
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	tccliCred := struct {
+		SecretId  string `json:"secretId"`
+		SecretKey string `json:"secretKey"`
+		Token     string `json:"token"`
+	}{}
+	if err := json.Unmarshal(data, &tccliCred); err != nil {
+		return nil, err
+	}
+
+	if tccliCred.SecretId == "" || tccliCred.SecretKey == "" {
+		return nil, tcerr.NewTencentCloudSDKError(creErr, "Failed to parse profile file,please confirm whether it contains \"secretId\" and \"secretKey\"", "")
+	}
+	return &Credential{
+		SecretId:  tccliCred.SecretId,
+		SecretKey: tccliCred.SecretKey,
+		Token:     tccliCred.Token,
+	}, nil
+}


### PR DESCRIPTION
Adds TccliProfileProvider (~/.tccli/<profile>.credential, profile via $TENCENTCLOUD_PROFILE) and inserts it plus TKE OIDC role ARN into DefaultProviderChain between Profile and CvmRole.